### PR TITLE
Clarified a step in MainViewController

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Since this table view controller is embedded in the `MainViewController`, it wil
 5. In the `prepare(for segue: ...)`, check for the embed segue's identifier. If it is, set the `recipesTableViewController` variable to the segue's `destination`. You will need to cast the view controller as the correct subclass.
 6. Create a variable `filteredRecipes: [Recipe] = []`. 
 7. Create a function called `filterRecipes()`. This will take the text from the text field and filter the recipes with it. In the function:
-    - Unwrap the search term, and make sure it isn't an empty string. If it is an empty string, set the value of `filteredRecipes` to `allRecipes`. If there is no search term, that means you should display all of the recipes.
+    - Unwrap the search term and make sure it isn't an empty string. If search term is empty or nil, set the value of `filteredRecipes` to `allRecipes`. If there is no search term, that means you should display all of the recipes.
     - If there is a non-empty search term in the text field, using the `filter` higher-order function to filter the `allRecipes` array. It should filter by checking if the recipe's `name` or `instructions` contains the search term. Set the value of the `filteredRecipes` to the result of the `filter` method.
 8. In the action of the text field, call `resignFirstResponder()` on the text field, then call `filterRecipes()`.
 9. Add a `didSet` property observer to the `filteredRecipes` variable. It should set the `recipeTableViewController`'s `recipes` to the `filteredRecipes`.


### PR DESCRIPTION
@armadsen 
I've had multiple students come to me with an incorrect implementation of MainViewController step 7 today, so I cleared up the description to suggest a better one:

The suggested code looked like:
```
guard let search = searchField.text else {return}
if search.isEmpty {
    filteredResults = allResults
} else {
    filteredResults =allResults.filter(...)
}
```
The bug here is that, if the search field's text is nil, filteredResults never gets set to allRecipes; hopefully my slight rewording implies that it should be:
```
if let search = searchField.text, !search.isEmpty {
    filteredResults = allRecipes.filter(...)
} else {
    filteredResults = allRecipes
}
```

I'd also like to add that it seems that the built-in "you're only allowed to access UIKit objects in the main thread" checker seems to be enabled by default in XCode 10; so far I've helped students use `DispatchQueue.main.async` for their code, but I think the better solution is to update the helper to wrap calls to the completion closure instead.